### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ and packaged it properly to use in pypi.
 Just include in your panels:
 
     app.config['DEBUG_TB_PANELS'].append('flask_debugtb_elasticsearch.panel.ElasticsearchDebugPanel')
+    
+Or:
+
+    app.config["DEBUG_TB_PANELS"] = list(app.config["DEBUG_TB_PANELS"])
+    app.config["DEBUG_TB_PANELS"].append('flask_debugtb_elasticsearch.panel.ElasticsearchDebugPanel')
 
 And that's all there is to it.
 


### PR DESCRIPTION
DEBUG_TB_PANELS in flask-debugtoolbar==0.11.0 is tuple and not a list.  
Adding it this way: `app.config['DEBUG_TB_PANELS'].append('flask_debugtb_elasticsearch.panel.ElasticsearchDebugPanel')` is causing error `AttributeError: 'tuple' object has no attribute 'append'`  
The easy solution is to convert DEBUG_TB_PANELS tuple to list.